### PR TITLE
refactor to only write to file once at the end plus multiple other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 config.config
 
 #results output
-results.txt
+results.csv
 
 #********************************************************************************************************
 #stock intellij gitignore from https://www.gitignore.io/api/playframework,sbt,eclipse,intellij,scala,osx

--- a/src/main/scala/app/api-utils/ArticleUrls.scala
+++ b/src/main/scala/app/api-utils/ArticleUrls.scala
@@ -5,8 +5,7 @@ import com.gu.contentapi.client.model.SearchQuery
 import org.joda.time.DateTime
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
+import scala.concurrent.Future
 
 class ArticleUrls(key: String) {
   val testApi:String = key
@@ -31,24 +30,10 @@ class ArticleUrls(key: String) {
       .contentType("liveblog")
 
     contentApiClient.getResponse(searchQuery) map { response =>
-      for (result <- response.results) yield { result.webUrl }
+      for (result <- response.results) yield {
+        println(result.webUrl)
+        result.webUrl }
     }
   }
-}
-
-
-object Test {
-
-  def test = {
-    List(1,2,3,4).map { chicken => chicken.toString } //List("1","2","3","4")
-  }
-
-  val futureCat = Future { "cat" }.map { animal => println(animal)} // "cat"
-  futureCat onSuccess {
-    case cat => println( cat + "Mow")
-  }
-
-  val cat = Await.result(futureCat, 5 seconds)
-
 }
 

--- a/src/main/scala/app/api-utils/WebPageTest.scala
+++ b/src/main/scala/app/api-utils/WebPageTest.scala
@@ -36,6 +36,11 @@ class WebPageTest(baseUrl: String, passedKey: String) {
     }
   }
 
+  def test(gnmPageUrl:String): ResultElement = {
+    val resultPage: String = sendPage(gnmPageUrl)
+    val testResults: ResultElement = getResults(resultPage)
+    testResults
+  }
 
 
   def sendPage(gnmPageUrl:String): String = {


### PR DESCRIPTION
Refactor to only write to file once at the end - to prepare for file to be in S3 bucket
Renamed output to results.csv and altered results to a more proper .csv format
Abstracted some of the work out of the main thread to make things more readable
Added many comments
