### PR TITLE
tidy up capi call

### DIFF
--- a/src/main/scala/app/App.scala
+++ b/src/main/scala/app/App.scala
@@ -47,7 +47,7 @@ object App {
       "http://www.theguardian.com/music/live/2016/jan/11/david-bowie-dies-of-cancer-aged-69-reports",
       "http://www.theguardian.com/world/live/2015/nov/14/paris-terror-attacks-attackers-dead-mass-killing-live-updates",
       "http://www.theguardian.com/us-news/live/2015/oct/13/cnn-democratic-debate-bernie-sanders-hillary-clinton-las-vegas",
-      "http://www.theguardian.com/politics/blog/live/2015/may/07/election-2015-live-final-votes-cast-as-battle-for-power-looms#noads")
+      "http://www.theguardian.com/politics/blog/live/2015/may/07/election-2015-live-final-votes-cast-as-battle-for-power-looms")
 
     println("defining new S3 Client (this is done regardless but only used if 'iamTestingLocally' flag is set to false)")
     val s3Client = new AmazonS3Client()

--- a/src/main/scala/app/App.scala
+++ b/src/main/scala/app/App.scala
@@ -100,8 +100,8 @@ object App {
     }
     else {
             // Send each article URL to the webPageTest API and obtain resulting data
-            println("Resutls returned from call to ArticleUrls.scala")
-            articleUrls.map(println(_))
+            println("combined results from CAPI calls")
+            articleUrls.foreach(println)
             val testResults: List[List[String]] = articleUrls.map(url => testUrlReturnHtml(url, wptBaseUrl, wptApiKey))
             // Add results to a single string so that we only need ot write to S3 once (S3 will only take complete objects).
             val resultsList: List[String] = testResults.map(x => x.head)

--- a/src/main/scala/app/App.scala
+++ b/src/main/scala/app/App.scala
@@ -47,7 +47,7 @@ object App {
       "http://www.theguardian.com/music/live/2016/jan/11/david-bowie-dies-of-cancer-aged-69-reports",
       "http://www.theguardian.com/world/live/2015/nov/14/paris-terror-attacks-attackers-dead-mass-killing-live-updates",
       "http://www.theguardian.com/us-news/live/2015/oct/13/cnn-democratic-debate-bernie-sanders-hillary-clinton-las-vegas",
-      "http://www.theguardian.com/politics/blog/live/2015/may/07/election-2015-live-final-votes-cast-as-battle-for-power-looms")
+      "http://www.theguardian.com/politics/blog/live/2015/may/07/election-2015-live-final-votes-cast-as-battle-for-power-looms#noads")
 
     println("defining new S3 Client (this is done regardless but only used if 'iamTestingLocally' flag is set to false)")
     val s3Client = new AmazonS3Client()
@@ -93,11 +93,15 @@ object App {
     val articleUrlList = new ArticleUrls(contentApiKey)
     //  Request a list of urls from Content API
     val articleUrls: List[String] = articleUrlList.getUrls
+    println(DateTime.now + " Closing Content API query connection")
+    articleUrlList.shutDown
     if (articleUrls.isEmpty) {
       println(DateTime.now + " WARNING: No results returned from Content API")
     }
     else {
             // Send each article URL to the webPageTest API and obtain resulting data
+            println("Resutls returned from call to ArticleUrls.scala")
+            articleUrls.map(println(_))
             val testResults: List[List[String]] = articleUrls.map(url => testUrlReturnHtml(url, wptBaseUrl, wptApiKey))
             // Add results to a single string so that we only need ot write to S3 once (S3 will only take complete objects).
             val resultsList: List[String] = testResults.map(x => x.head)
@@ -107,8 +111,6 @@ object App {
             simplifiedResults = simplifiedResults.concat(simplifiedResultsList.mkString)
             println(DateTime.now + " Results added to accumulator string \n")
         }
-    println(DateTime.now + " Closing Content API query connection")
-    articleUrlList.shutDown
     roguesGalleryResults = roguesGalleryResults.concat(testRoguesGallery(roguesGallery ,wptBaseUrl, wptApiKey))
     results = results.concat(hTMLTableFooters)
     results = results.concat(hTMLPageFooterStart + DateTime.now + hTMLPageFooterEnd)


### PR DESCRIPTION
This will stop capi call hanging when webpagetest run falls over - means job wont be stuck on the same run forever should it break
