### PR TITLE
makes html tags inline for email alerts as gmail strips them

### DIFF
--- a/src/main/scala/app/api-utils/HtmlStringOperations.scala
+++ b/src/main/scala/app/api-utils/HtmlStringOperations.scala
@@ -12,6 +12,12 @@ class HtmlStringOperations(average: String, warning: String, alert: String, live
   val warningColor = warning
   val alertColor = alert
 
+  val liveBlogResultsPage: String = liveBlogResultsUrl
+  val interactiveResultsPage: String = interactiveResultsUrl
+  val frontsResultsPage: String = frontsResultsUrl
+
+  //HTML
+  //HTML Page elements
   val hTMLPageHeader: String = "<!DOCTYPE html>\n<html>\n<head>\n  <link rel=\"stylesheet\" href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css\" integrity=\"sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7\" crossorigin=\"anonymous\">\n</head>\n<body>\n"
   val hTMLTitleLiveblog: String = "<h1>Currrent Performance of today's Liveblogs</h1>"
   val hTMLTitleInteractive: String = "<h1>Currrent Performance of today's Interactives</h1>"
@@ -20,16 +26,36 @@ class HtmlStringOperations(average: String, warning: String, alert: String, live
   val hTMLFullTableHeaders: String = "<table class=\"table table-striped\">\n<tr>\n<th>Time Last Tested</th>\n<th>Test Type</th>\n<th>Article Url</th>\n<th>Time to First Paint</th>\n<th>Time to Document Complete</th>\n<th>MB transferred at Document Complete</th>\n<th>Time to Fully Loaded</th>\n<th>MB transferred at Fully Loaded</th>\n<th>US Prepaid Cost $US0.097 per MB</th>\n<th>US Postpaid Cost $US0.065 per MB</th>\n<th>Speed Index</th>\n<th>Status</th>\n</tr>\n"
   val hTMLSimpleTableHeaders: String = "<table class=\"table table-striped\">\n<tr>\n<th>Time Last Tested</th>\n<th>Test Type</th>\n<th>Article Url</th>\n<th>Time to Page Scrollable</th>\n<th>Time to rendering above the fold complete </th>\n<th>MB transferred</th>\n<th>US Prepaid Cost $US0.097 per MB</th>\n<th>US Postpaid Cost $US0.065 per MB</th>\n<th>Status</th>\n</tr>\n"
   val hTMLInteractiveTableHeaders: String = "<table class=\"table table-striped\">\n<tr>\n<th>Time Last Tested</th>\n<th>Test Type</th>\n<th>Article Url</th>\n<th>Time to Page Scrollable</th>\n<th>Time to rendering above the fold complete </th>\n<th>MB transferred</th>\n<th>Status</th>\n</tr>\n"
-  val hTMLAlertTableHeaders: String = "<table class=\"table table-striped\">\n<tr style=\"background-color:" + averageColor + ";\">\n<th>Article Url</th>\n<th>Test Type</th>\n<th>Status</th>\n</tr>\n"
   val hTMLTableFooters: String = "</table>"
   val hTMLPageFooterStart: String = "\n<p><i>Job completed at: "
   val hTMLPageFooterEnd: String = "</i></p>\n</body>\n</html>"
   //  var results: String = hTMLPageHeader + hTMLTitleLiveblog + hTMLJobStarted + hTMLTableHeaders
   //  var simplifiedResults: String = hTMLPageHeader + hTMLTitleLiveblog + hTMLJobStarted + hTMLSimpleTableHeaders
-  val liveBlogResultsPage: String = liveBlogResultsUrl
-  val interactiveResultsPage: String = interactiveResultsUrl
-  val frontsResultsPage: String = frontsResultsUrl
 
+
+  //Email
+  //tags with inline styles for email
+  val h1EmailTag: String = "<!DOCTYPE html>\n<html style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;font-family: sans-serif;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;font-size: 10px;-webkit-tap-highlight-color: rgba(0,0,0,0);\">\n<head style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;\">\n  <link rel=\"stylesheet\" href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css\" integrity=\"sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7\" crossorigin=\"anonymous\" style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;\">\n</head>\n<body style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0;font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;font-size: 14px;line-height: 1.42857143;color: #333;background-color: #fff;\">\n<h1 style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: .67em 0;font-size: 36px;font-family: inherit;font-weight: 500;line-height: 1.1;color: inherit;margin-top: 20px;margin-bottom: 10px;\">"
+  val h2EmailTag: String = "<h2 style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;orphans: 3;widows: 3;page-break-after: avoid;font-family: inherit;font-weight: 500;line-height: 1.1;color: inherit;margin-top: 20px;margin-bottom: 10px;font-size: 30px;\">"
+  val pEmailTag: String = "<p style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;orphans: 3;widows: 3;margin: 0 0 10px;\">"
+  val tableEmailTag: String = "<table class=\"table table-striped\" style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;border-spacing: 0;border-collapse: collapse!important;background-color: transparent;width: 100%;max-width: 100%;margin-bottom: 20px;\">"
+  val tableHeaderRowEmailTag: String = "<tr style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;page-break-inside: avoid;\">"
+  val tableHeaderCellEmailTag: String = "<th style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;padding: 0;text-align: left;background-color: #fff!important;\">"
+  val tableNormalRowEmailTag: String = "<tr style=\"background-color: ;-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;page-break-inside: avoid;\" #d9edf7\";\">"
+  val tableNormalCellEmailTag: String = "<td style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;padding: 0;background-color: #fff!important;\">"
+
+  val aHrefEmailStyle: String = "style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: underline;\""
+
+  //email elements
+  val emailPageHeader: String = "<!DOCTYPE html>\n<html style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;font-family: sans-serif;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;font-size: 10px;-webkit-tap-highlight-color: rgba(0,0,0,0);\">\n<head style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;\">\n  <link rel=\"stylesheet\" href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css\" integrity=\"sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7\" crossorigin=\"anonymous\" style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;\">\n</head>\n<body style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0;font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;font-size: 14px;line-height: 1.42857143;color: #333;background-color: #fff;\">"
+  val htmlTitleEmailLiveBlog: String = h1EmailTag + "Current Performance of today's Liveblogs</h1>"
+  val htmlTitleEmailInteractive: String = h1EmailTag + "Current Performance of today's Interactives</h1>"
+  val htmlTitleEmailFronts: String = h1EmailTag + "Current Performance of today's Fronts</h1>"
+  val hTMLEmailJobStarted: String =  pEmailTag + "Job started at: " + DateTime.now + "\n</p>"
+  val hTMLAlertEmailTableHeaders: String = tableEmailTag + "\n" + tableHeaderRowEmailTag + "\n" + tableHeaderCellEmailTag + "Article Url</th>\n" + tableHeaderCellEmailTag + "Test Type</th>\n" + tableHeaderCellEmailTag + "Status</th>\n</tr>\n"
+  val hTMLEmailTableFooters: String = "</table>"
+  val hTMLEmailPageFooterStart: String = "\n"+ pEmailTag +"<i>Job completed at: "
+  val hTMLEmailPageFooterEnd: String = "</i></p>\n</body>\n</html>"
 
   def generateHTMLRow(resultsObject: PerformanceResultsObject): String = {
     var returnString: String = ""
@@ -111,42 +137,42 @@ class HtmlStringOperations(average: String, warning: String, alert: String, live
   }
 
   def generalAlertEmailHeadings(): String = {
-    val messageString: String = hTMLPageHeader +
-      "<h1>Page performance alerts</h1>"
+    val messageString: String = emailPageHeader +
+      h1EmailTag + "Page performance alerts" + "</h1>"
     messageString
   }
 
   def interactiveAlertEmailHeadings(): String = {
-    val messageString: String = hTMLPageHeader +
-      "<h1>Interactive performance alerts</h1>\n"
+    val messageString: String = emailPageHeader +
+      h1EmailTag + "Interactive performance alerts" + "</h1>\n"
     messageString
   }
 
   def generateLiveBlogAlertHeadings(): String = {
-    "<h2>Live Blog Performance Alerts</h2>\n"
+    h2EmailTag + "Live Blog Performance Alerts" + "</h2>\n"
   }
 
   def generateLiveBlogAlertFooter(): String = {
-    "<p>All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content\n</p>" +
-    "<p>Full results for LiveBlogs can be viewed <a href=" + liveBlogResultsPage + ">here</a></p>"
+    pEmailTag + "All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content" +"</p>\n" +
+    pEmailTag + "Full results for LiveBlogs can be viewed <a href=" + liveBlogResultsPage + ">here</a></p>\n"
   }
 
   def generateInteractiveAlertHeadings(): String = {
-    "<h2>Interactive Performance Alerts</h2>\n"
+    h2EmailTag + "Interactive Performance Alerts" + "</h2>\n"
   }
 
   def generateInteractiveAlertFooter(): String = {
-    "<p>All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content\n</p>" +
-    "<p>Full results for Interactives can be viewed <a href=" + interactiveResultsPage + ">here</a></p>"
+    pEmailTag + "All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content"+"</p>\n" +
+    pEmailTag + "Full results for Interactives can be viewed <a href=" + interactiveResultsPage + ">here</a></p>\n"
   }
 
   def generateFrontsAlertHeadings(): String = {
-    "<h2>Fronts Performance Alerts</h2>\n"
+    h2EmailTag + "Fronts Performance Alerts" + "</h2>\n"
   }
 
   def generateFrontsAlertFooter(): String = {
-    "<p>All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content\n</p>" +
-      "<p>Full results for Fronts can be viewed <a href=" + frontsResultsPage + ">here</a></p>"
+    pEmailTag + "All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content</p>\n" +
+      pEmailTag + "Full results for Fronts can be viewed <a href=" + frontsResultsPage + ">here</a></p>\n"
   }
 
 
@@ -157,10 +183,10 @@ class HtmlStringOperations(average: String, warning: String, alert: String, live
     if(alertList.nonEmpty) {
       val desktopMessageString: String =
         if (alertList.exists(test => test.typeOfTest == "Desktop")) {
-          "<h2>Desktop Alerts</h2>" +
-            "<p>The following items have been found to either take too long to load or cost too much to view on a desktop browser</p>\n" +
-            this.hTMLAlertTableHeaders + "\n" +
-            (for (test <- alertList if test.typeOfTest == "Desktop") yield "<tr>" + test.toHTMLAlertMessageCells() + "</tr>").mkString +
+          h2EmailTag + "Desktop Alerts</h2>" +
+            pEmailTag + "The following items have been found to either take too long to load or cost too much to view on a desktop browser</p>\n" +
+            this.hTMLAlertEmailTableHeaders + "\n" +
+            (for (test <- alertList if test.typeOfTest == "Desktop") yield tableNormalRowEmailTag + test.toHTMLAlertMessageCells() + "</tr>").mkString +
             this.hTMLTableFooters
         }
         else {
@@ -169,13 +195,13 @@ class HtmlStringOperations(average: String, warning: String, alert: String, live
 
       val mobileMessageString: String =
         if (alertList.exists(test => test.typeOfTest == "Android/3G")) {
-          "<h2>Mobile Alerts</h2>" +
-            "<p>The following items have been found to either take too long to load or cost too much to view on a mobile device</p>\n" +
-            this.hTMLAlertTableHeaders + "\n" +
-            (for (test <- alertList if test.typeOfTest == "Android/3G") yield test.toHTMLAlertMessageCells() + "</tr>").mkString +
+          h2EmailTag + "Mobile Alerts</h2>" +
+            pEmailTag + "The following items have been found to either take too long to load or cost too much to view on a mobile device</p>\n" +
+            this.hTMLAlertEmailTableHeaders + "\n" +
+            (for (test <- alertList if test.typeOfTest == "Android/3G") yield tableNormalRowEmailTag + test.toHTMLAlertMessageCells() + "</tr>").mkString +
             this.hTMLTableFooters
 
-            "<p>All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content</p>"
+            pEmailTag + "All alerts have been confirmed by retesting multiple times. Tests were run without ads so all page weight is due to content" + "</p>\n"
         }
         else {
           ""

--- a/src/main/scala/app/api-utils/PerformanceResultsObject.scala
+++ b/src/main/scala/app/api-utils/PerformanceResultsObject.scala
@@ -85,7 +85,17 @@ class PerformanceResultsObject(url:String, testType: String, tTFB: Int, tFP:Int,
   }
 
   def toHTMLAlertMessageCells(): String = {
-    "<td><a href=" + testUrl + ">" + testUrl + "</a>" + "</td>" + "<td>" + typeOfTest + "</td>" + "<td>"+ genTestResultString() +"</td>" +
+    //Email
+    //tags with inline styles for email
+    val pEmailTag: String = "<p style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;orphans: 3;widows: 3;margin: 0 0 10px;\">"
+    val tableNormalRowEmailTag: String = "<tr style=\"background-color: ;-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;page-break-inside: avoid;\" #d9edf7\";\">"
+    val tableNormalCellEmailTag: String = "<td style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;padding: 0;background-color: #fff!important;\">"
+
+    val aHrefEmailStyle: String = "style=\"-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: underline;\""
+
+
+
+    tableNormalCellEmailTag + "<a href=" + testUrl + aHrefEmailStyle + ">" + testUrl + "</a>" + "</td>" + tableNormalCellEmailTag + typeOfTest + "</td>" + tableNormalCellEmailTag + genTestResultString() +"</td>" +
     "<tr>List of 5 heaviest elements on page - Recommend reviewing these items </tr>" +
     "<tr><td>Resource</td><td>Content Type</td><td>Bytes Transferred</td></tr>" +
       heavyElementList.map(element => element.alertHTMLString()).mkString


### PR DESCRIPTION
used http://templates.mailchimp.com/resources/inline-css/ to determine what inline styles should be.
Note this is only changed for the email alert as apparently gmail strips header links and many header styles from its mail as a security precaution.
