### PR TITLE
attempt to use try and catch to prevent catastrophic error when parsing wpt results

### DIFF
--- a/src/main/scala/app/App.scala
+++ b/src/main/scala/app/App.scala
@@ -25,7 +25,6 @@ object App {
     println("Job started at: " + DateTime.now)
     println("Local Testing Flag is set to: " + iamTestingLocally.toString)
 
-    // todo - wire in publication date and use it to make sure things dont stick forever
     //  Define names of s3bucket, configuration and output Files
     val amazonDomain = "https://s3-eu-west-1.amazonaws.com"
     val s3BucketName = "capi-wpt-querybot"

--- a/src/main/scala/app/App.scala
+++ b/src/main/scala/app/App.scala
@@ -444,20 +444,18 @@ object App {
         combinedMobileHTMLResults.mkString +
         htmlString.closeTable + htmlString.closePage
 
-//      val editorialPageWeightDashboard: String = newhtmlString.generateHTMLPage(sortedByWeightCombinedResults)
-      val editorialPageWeightDashboardCombined = new PageWeightDashboardCombined(sortedByWeightCombinedResults)
-//      val editorialPageWeightDashboardDesktop: String = newhtmlString.generateHTMLPage(sortedByWeightCombinedDesktopResults)
-      val editorialPageWeightDashboardDesktop = new PageWeightDashboardDesktop(sortedByWeightCombinedDesktopResults)
-//      val editorialPageWeightDashboardMobile: String = newhtmlString.generateHTMLPage(sortedCombinedByWeightMobileResults)
-      val editorialPageWeightDashboardMobile = new PageWeightDashboardMobile(sortedCombinedByWeightMobileResults)
+    val editorialPageWeightDashboardCombined = new PageWeightDashboardCombined(sortedByWeightCombinedResults)
+    val editorialPageWeightDashboardDesktop = new PageWeightDashboardDesktop(sortedByWeightCombinedDesktopResults)
+    val editorialPageWeightDashboardMobile = new PageWeightDashboardMobile(sortedCombinedByWeightMobileResults)
+    val editorialPageWeightDashboard = new PageWeightDashboardTabbed(sortedByWeightCombinedResults, sortedByWeightCombinedDesktopResults, sortedCombinedByWeightMobileResults)
 
-      val editorialPageWeightDashboard = new PageWeightDashboardTabbed(sortedByWeightCombinedResults, sortedByWeightCombinedDesktopResults, sortedCombinedByWeightMobileResults)
+//  strip out errors
+    val errorFreeSortedByWeightCombinedResults = for (result <- sortedByWeightCombinedDesktopResults if(result.speedIndex != -1)) yield result
+//record results
+    val resultsToRecord = (errorFreeSortedByWeightCombinedResults ::: oldResults).take(1000)
+    val resultsToRecordCSVString: String = resultsToRecord.map(_.toCSVString()).mkString
 
-      //record results
-      val resultsToRecord = (sortedByWeightCombinedResults ::: oldResults).take(1000)
-      val resultsToRecordCSVString: String = resultsToRecord.map(_.toCSVString()).mkString
-
-    //Generate Lists for sortBySpeed combined pages
+//Generate Lists for sortBySpeed combined pages
     val sortedBySpeedCombinedResults: List[PerformanceResultsObject] = orderListBySpeed(combinedResultsList ::: dedupedUnchangedResults)
     val sortedBySpeedCombinedDesktopResults: List[PerformanceResultsObject] = sortHomogenousResultsBySpeed(combinedDesktopResultsList)
     val sortedBySpeedCombinedMobileResults: List[PerformanceResultsObject] = sortHomogenousResultsBySpeed(combinedMobileResultsList)

--- a/src/main/scala/app/api-utils/PageElement.scala
+++ b/src/main/scala/app/api-utils/PageElement.scala
@@ -204,7 +204,7 @@ class PageElementFromHTMLTableRow(htmlTableRow: String) extends PageElement{
     val returnString: String = "<tr>" +
       "<td><a href = \"" + resource + "\">" + resource + "</a></td>" +
       "<td>" + contentType + "</td>" +
-      "<td>" + sizeInKB + "KB</td>" +
+      "<td>" + sizeInMB + "MB</td>" +
       "</tr>"
     returnString
   }

--- a/src/main/scala/app/api-utils/html/pages/PageWeightEmailTemplate.scala
+++ b/src/main/scala/app/api-utils/html/pages/PageWeightEmailTemplate.scala
@@ -66,7 +66,7 @@ class PageWeightEmailTemplate (resultsList: List[PerformanceResultsObject]) {
 
   def generateHTMLDataRows(resultsList: List[PerformanceResultsObject]): String = {
     (for (result <- resultsList) yield {
-      "<tr class=\"pageclass default\">" + "<td> The article: " + "<a href=\"" + result.testUrl + "\">" + result.headline + "</a>" +
+      "<tr class=\"pageclass default\">" + "<td> The article: " + "<a href=\"" + result.testUrl + "\">" + result.headline.getOrElse(result.testUrl) + "</a>" +
        "is weighing in at " + result.mBInFullyLoaded + " MB." + "</td>" + "</tr>" + "\n" +
         generatePageElementTable(result)
     }).mkString

--- a/src/main/scala/app/api-utils/html/pages/PageWeightEmailTemplate.scala
+++ b/src/main/scala/app/api-utils/html/pages/PageWeightEmailTemplate.scala
@@ -30,13 +30,12 @@ class PageWeightEmailTemplate (resultsList: List[PerformanceResultsObject]) {
     "</div>"
 
   //Page Content
-  val HTML_PAGE_CONTENT: String = "<div id=\"content\">" + "\n" +
-    "<h2>Hi, \nThe following pages have been found to be too heavy and require investigation</h2>" + "\n"
+  val HTML_PAGE_CONTENT: String = "<div id=\"content\">" + "\n"
 
   //Page Tables
   val HTML_REPORT_TABLE_HEADERS: String = "<table id=\"report\">"+ "\n" +
     "<thead>" + "\n" +
-    "<tr> <th>Time Last Tested</th>" + "<th>Test Type</th>" + "<th>Headline</th>" + "<th>Type of Page</th>" + "<th>Time till page looks loaded</th>" + "<th>Page weight (MB)</th>" + "<th>Click for more details</th>" + "</tr>"+ "\n" +
+    "<tr> <th>You have been alerted because the following pages have been found to be too heavy and require investigation</th>" + "</tr>"+ "\n" +
     "</thead>" +"\n" +
     "<tbody>"
 


### PR DESCRIPTION
If I am parsing wpt and there is a problem with the test, the XML parsing crashes and currently brings down the whole run.
This is an attempt to encapsulate XML parsing in try/catch in order to fail softly on exceptions without killing the entire run.
