### PR TITLE
Prevent dupes part1

### DIFF
--- a/src/main/scala/app/App.scala
+++ b/src/main/scala/app/App.scala
@@ -442,7 +442,7 @@ object App {
     val editorialPageWeightDashboard = new PageWeightDashboardTabbed(sortedByWeightCombinedResults, sortedByWeightCombinedDesktopResults, sortedCombinedByWeightMobileResults)
 
 //record results
-    val resultsToRecord = (errorFreeSortedByWeightCombinedResults ::: previousTestResultsHandler.oldResults).take(3000)
+    val resultsToRecord = previousTestResultsHandler.removeDuplicates(errorFreeSortedByWeightCombinedResults ::: previousTestResultsHandler.oldResults).take(3000)
     val resultsToRecordCSVString: String = resultsToRecord.map(_.toCSVString()).mkString
 
 //Generate Lists for sortBySpeed combined pages

--- a/src/test/java/ResultListTests.scala
+++ b/src/test/java/ResultListTests.scala
@@ -72,6 +72,8 @@ class ResultListTests extends ResultListUnitSpec with Matchers {
 
   val oldResultList = List(testResult1m, testResult1d, testResult2m, testResult3m, testResult3d, testResult4m, testResult4d, testResult5m,  testResult5d, testResult6m, testResult6d)
 
+  val listWithDupes = List(testResult1d, testResult1m, testResult2m, testResult2m, testResult1d, testResult3d, testResult4d, testResult4m, testResult4m, testResult5d, testResult4m, testResult6d, testResult6m, testResult6m)
+
   val prevResults = new ResultsFromPreviousTests(oldResultList)
 
 
@@ -102,6 +104,23 @@ class ResultListTests extends ResultListUnitSpec with Matchers {
 
   "All lists in previous results object" should "be conistent in number" in {
     assert(prevResults.checkConsistency())
+  }
+
+  "When Remove Duplicates is called on a list it" should "return the correct list" in {
+    val cleanedList = prevResults.removeDuplicates(listWithDupes)
+    assert(cleanedList.length == 9)
+//    println(cleanedList.map(result => (result.testUrl,result.typeOfTest)).mkString)
+    val cleanedListArray = cleanedList.toArray
+    assert((cleanedListArray(0).testUrl, cleanedListArray(0).typeOfTest) == (testResult1d.testUrl,testResult1d.typeOfTest))
+    assert((cleanedListArray(1).testUrl, cleanedListArray(1).typeOfTest) == (testResult1m.testUrl,testResult1m.typeOfTest))
+    assert((cleanedListArray(2).testUrl, cleanedListArray(2).typeOfTest) == (testResult2m.testUrl,testResult2m.typeOfTest))
+    assert((cleanedListArray(3).testUrl, cleanedListArray(3).typeOfTest) == (testResult3d.testUrl,testResult3d.typeOfTest))
+    assert((cleanedListArray(4).testUrl, cleanedListArray(4).typeOfTest) == (testResult4d.testUrl,testResult4d.typeOfTest))
+    assert((cleanedListArray(5).testUrl, cleanedListArray(5).typeOfTest) == (testResult4m.testUrl,testResult4m.typeOfTest))
+    assert((cleanedListArray(6).testUrl, cleanedListArray(6).typeOfTest) == (testResult5d.testUrl,testResult5d.typeOfTest))
+    assert((cleanedListArray(7).testUrl, cleanedListArray(7).typeOfTest) == (testResult6d.testUrl,testResult6d.typeOfTest))
+    assert((cleanedListArray(8).testUrl, cleanedListArray(8).typeOfTest) == (testResult6m.testUrl,testResult6m.typeOfTest))
+
   }
 
 

--- a/src/test/java/ResultListTests.scala
+++ b/src/test/java/ResultListTests.scala
@@ -120,7 +120,11 @@ class ResultListTests extends ResultListUnitSpec with Matchers {
     assert((cleanedListArray(6).testUrl, cleanedListArray(6).typeOfTest) == (testResult5d.testUrl,testResult5d.typeOfTest))
     assert((cleanedListArray(7).testUrl, cleanedListArray(7).typeOfTest) == (testResult6d.testUrl,testResult6d.typeOfTest))
     assert((cleanedListArray(8).testUrl, cleanedListArray(8).typeOfTest) == (testResult6m.testUrl,testResult6m.typeOfTest))
+  }
 
+  "When removeDuplicates is called on a list with no duplicates it" should "return an identical list" in {
+    val cleanedList = prevResults.removeDuplicates(oldResultList)
+    assert(cleanedList == oldResultList)
   }
 
 


### PR DESCRIPTION
This prevents loading and saving of duplicate records.
dupes are now stripped from the previousResults file before use and before file saving.
This will remove existing dupes and prevent accumulation of future duplicates.
Still need to check code to discover where duplicates came from in the first place.
