### PR TITLE
update to match the identifier on the page element table in web-page-test

### DIFF
--- a/src/main/scala/app/api-utils/WebPageTest.scala
+++ b/src/main/scala/app/api-utils/WebPageTest.scala
@@ -478,7 +478,7 @@ class WebPageTest(baseUrl: String, passedKey: String, urlFragments: List[String]
 
   def trimToHTMLTable(pageHTML: String): String = {
     //    val responseStringXML: Elem = scala.xml.XML.loadString(response.body.string)
-    val responseStringOuterTableStart: Int = pageHTML.indexOf("<table id=\"tableDetails\" class=\"details center\">")
+    val responseStringOuterTableStart: Int = pageHTML.indexOf("<table class=\"tableDetails details center\">")
     val responseStringOuterTableEnd: Int = pageHTML.indexOf("</table>", responseStringOuterTableStart)
     val outerTableString: String = pageHTML.slice(responseStringOuterTableStart, responseStringOuterTableEnd)
     val innerTableStart: Int = outerTableString.indexOf("<tbody>")


### PR DESCRIPTION
Webpagetest details page changed the layout of their html.
As a result, we were not getting the page elements pulling through from our handling of test results.
This rectifies that problem. 
