### PR TITLE
Fix xml parsing issue

### DIFF
--- a/app/services/api-utils/WebPageTest.scala
+++ b/app/services/api-utils/WebPageTest.scala
@@ -276,7 +276,7 @@ class WebPageTest(baseUrl: String, passedKey: String, urlFragments: List[String]
       }
       val testSummaryPage: String = (rawXMLResult \\ "response" \ "data" \ "summary").text.toString
       val timeToFirstByte: Int = (rawXMLResult \\ "response" \ "data" \ "run" \ "firstView" \ "results" \ "TTFB").text.toInt
-      val firstPaint: Int = (rawXMLResult \\ "response" \ "data" \ "run" \ "firstView" \ "results" \ "firstPaint").text.toInt
+      val firstPaint: Int = (rawXMLResult \\ "response" \ "data" \ "run" \ "firstView" \ "results" \ "firstPaint").text.toDouble.toInt
       Logger.info("firstPaint = " + firstPaint)
       val docTime: Int = (rawXMLResult \\ "response" \ "data" \ "run" \ "firstView" \ "results" \ "docTime").text.toInt
       Logger.info("docTime = " + docTime)


### PR DESCRIPTION
xml was unable to convert test with decimals directly to Int
This change allows it to convert the text to a Double, which can then be easily converted to an Int

Reason for change:
The inability to parse the xml file was causing every result to fail.