### PR TITLE
restrict liveblogging flag to items updated in the last 24 hours

### DIFF
--- a/test/WPTTest.scala
+++ b/test/WPTTest.scala
@@ -1,0 +1,3 @@
+class WPTTest {
+
+}


### PR DESCRIPTION
Currently a large number of duplicate items are being constantly retested this is "gumming up the works" and causing job runs to time out.
Most of these duplicates are either interactives or liveblogs whose "currently liveblogging" flag is recorded as true despiite being several days old.
This  change will restrict the "is currently liveblogging" flag to content that has been updated in the last 24 hours.